### PR TITLE
Update for R >= 4.0.0 etc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VER_RLANG="3.6.2"
+ARG VER_RLANG="3.6.3"
 
 FROM rocker/verse:${VER_RLANG} as rstudio
 
@@ -6,12 +6,12 @@ FROM scratch
 
 COPY --from=rstudio / /
 
-ARG VER_PYTHON="3.7"
-ARG VER_PWSH="6.2.4"
-ARG VER_SHINYPROXY="2.3.0"
-ARG VER_VSCODE="2.1698-vsc1.41.1"
-ARG VER_CRONICLE="0.8.44"
-ARG TAG="latest"
+ARG VER_PYTHON="3.9"
+ARG VER_PWSH="7.1.4"
+ARG VER_SHINYPROXY="2.5.0"
+ARG VER_VSCODE="3.11.1"
+ARG VER_CRONICLE="0.8.61"
+ARG TAG="dev"
 ENV TAG=${TAG}
 
 LABEL maintainer="dm3ll3n@gmail.com"
@@ -29,7 +29,7 @@ RUN apt-get update && \
     apt-get install -y curl nano
 
 # install Java 8 and ShinyProxy
-RUN apt-get install -y openjdk-8-jdk-headless && \
+RUN apt-get install -y openjdk-11-jdk-headless && \
     mkdir -p /opt/shinyproxy && \
     wget -nv "https://www.shinyproxy.io/downloads/shinyproxy-${VER_SHINYPROXY}.jar" -O /opt/shinyproxy/shinyproxy.jar
 
@@ -48,8 +48,8 @@ COPY samples /srv/shiny-server
 
 # install pwsh.
 # https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux
-RUN apt-get install -y libc6 libgcc1 libgssapi-krb5-2 liblttng-ust0 libstdc++6 libcurl3 libunwind8 libuuid1 zlib1g libssl1.0.2 libicu57 && \
-    wget -nv "https://github.com/PowerShell/PowerShell/releases/download/v${VER_PWSH}/powershell_${VER_PWSH}-1.debian.9_amd64.deb" -O /tmp/pwsh.deb && \
+RUN apt-get install -y less locales ca-certificates libicu63 libssl1.1 libc6 libgcc1 libgssapi-krb5-2 liblttng-ust0 libstdc++6 zlib1g curl && \
+    wget -nv "https://github.com/PowerShell/PowerShell/releases/download/v${VER_PWSH}/powershell_${VER_PWSH}-1.debian.10_amd64.deb" -O /tmp/pwsh.deb && \
     dpkg -i /tmp/pwsh.deb && \
     rm -f /tmp/pwsh.deb
 
@@ -66,11 +66,11 @@ RUN wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.
 ENV PATH "/conda3/bin:${PATH}"
 RUN echo "export PATH=\"/conda3/bin:\${PATH}\"" >> /etc/profile && \
     echo ". activate $VIRTUAL_ENV" >> /etc/profile && \
-    echo '$env:PATH = "/conda3/envs/$($env:VIRTUAL_ENV)/bin:" + $env:PATH' >> /opt/microsoft/powershell/6/profile.ps1
+    echo '$env:PATH = "/conda3/envs/$($env:VIRTUAL_ENV)/bin:" + $env:PATH' >> /opt/microsoft/powershell/7/profile.ps1
 
 # install VS code-server.
 RUN VER_CODESERVER=$(echo "$VER_VSCODE" | cut -d'-' -f1) && \
-    wget -nv "https://github.com/cdr/code-server/releases/download/${VER_CODESERVER}/code-server${VER_VSCODE}-linux-x86_64.tar.gz" -O /tmp/vs-code-server.tar.gz && \
+    wget -nv "https://github.com/cdr/code-server/releases/download/v${VER_CODESERVER}/code-server-${VER_VSCODE}-linux-amd64.tar.gz" -O /tmp/vs-code-server.tar.gz && \
     mkdir /tmp/vs-code-server && \
     tar -xzf /tmp/vs-code-server.tar.gz --strip 1 --directory /tmp/vs-code-server && \
     mv -f /tmp/vs-code-server/code-server /usr/local/bin/code-server && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,16 +72,8 @@ RUN echo "export PATH=\"/conda3/bin:\${PATH}\"" >> /etc/profile && \
     echo ". activate $VIRTUAL_ENV" >> /etc/profile && \
     echo '$env:PATH = "/conda3/envs/$($env:VIRTUAL_ENV)/bin:" + $env:PATH' >> /opt/microsoft/powershell/7/profile.ps1
 
-# install VS code-server.
-RUN VER_CODESERVER=$(echo "$VER_VSCODE" | cut -d'-' -f1) && \
-    wget -nv "https://github.com/cdr/code-server/releases/download/v${VER_CODESERVER}/code-server-${VER_VSCODE}-linux-amd64.tar.gz" -O /tmp/vs-code-server.tar.gz && \
-    mkdir /tmp/vs-code-server && \
-    tar -xzf /tmp/vs-code-server.tar.gz --strip 1 --directory /tmp/vs-code-server && \
-    mv -f /tmp/vs-code-server/code-server /usr/local/bin/code-server && \
-    rm -rf /tmp/vs-code-server.tar.gz && \
-    # unsure why this is necessary, but it solves a fatal 'file not found' error.
-    mkdir -p /src/packages/server/build/web && \
-    echo '' > /src/packages/server/build/web/index.html
+## install VS code-server.
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/usr/local --version=${VER_VSCODE}
 
 # install cronicle.
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash && \

--- a/configs/shinyproxy/application.yml
+++ b/configs/shinyproxy/application.yml
@@ -25,7 +25,7 @@ proxy:
     - id: reports
       display-name: Apps & Reports
       logo-url: 'fas fa-chart-line'
-      container-image: dm3ll3n/shinystudio:${TAG}
+      container-image: shinystudio:${TAG}
       container-cmd: [ "shiny-server" ]
       container-network: shinystudio-net
       container-volumes:
@@ -40,7 +40,7 @@ proxy:
     - id: documents
       display-name: Documents
       logo-url: 'fas fa-file-alt'
-      container-image: dm3ll3n/shinystudio:${TAG}
+      container-image: shinystudio:${TAG}
       container-cmd: [ "shiny-server" ]
       container-network: shinystudio-net
       container-volumes:
@@ -55,7 +55,7 @@ proxy:
     - id: personal
       display-name: Personal
       logo-url: 'far fa-folder-open'
-      container-image: dm3ll3n/shinystudio:${TAG}
+      container-image: shinystudio:${TAG}
       container-cmd: [ "shiny-server" ]
       container-network: shinystudio-net
       container-volumes:
@@ -70,7 +70,7 @@ proxy:
     - id: rstudio
       display-name: RStudio
       logo-url: 'fab fa-r-project'
-      container-image: dm3ll3n/shinystudio:${TAG}
+      container-image: shinystudio:${TAG}
       container-cmd: [ "rstudio" ]
       container-network: shinystudio-net
       container-volumes:
@@ -89,7 +89,7 @@ proxy:
     - id: vscode
       display-name: Visual Studio Code
       logo-url: 'fas fa-terminal'
-      container-image: dm3ll3n/shinystudio:${TAG}
+      container-image: shinystudio:${TAG}
       container-cmd: [ "vscode" ]
       container-network: shinystudio-net
       container-volumes:

--- a/configs/shinyproxy/application.yml
+++ b/configs/shinyproxy/application.yml
@@ -76,13 +76,15 @@ proxy:
       container-volumes:
         - "${CONTENT_PATH}/sites/${SITE_NAME}:/home/#{proxy.userId}/__ShinyStudio__:z"
         - "${CONTENT_PATH}/users/#{proxy.userId}:/home/#{proxy.userId}/__Personal__:z"
-        - "${CONTENT_PATH}/users/#{proxy.userId}/.rstudio:/home/#{proxy.userId}/.rstudio/monitored/user-settings:z"
+        - "${CONTENT_PATH}/users/#{proxy.userId}/.config:/home/#{proxy.userId}/.config:z"
+        - "${CONTENT_PATH}/users/#{proxy.userId}/.rstudio:/home/#{proxy.userId}/.local/share/rstudio:z"
         - "${SITE_NAME}_r_libraries:/r-libs"
         - "${SITE_NAME}_py_environment:/conda3"
         - "${SITE_NAME}_pwsh_modules:/home/#{proxy.userId}/.local/share/powershell/Modules"
       container-env:
         USER: "#{proxy.userId}"
         USERID: ${USERID}
+        WWW_ROOT_PATH: "#{proxySpec.containerSpecs[0].env.get('SHINYPROXY_PUBLIC_PATH')}"
       description: Full Screen
       port: 8787
       access-groups: [ 'admins' ]

--- a/configs/vscode/install-vscode-python.sh
+++ b/configs/vscode/install-vscode-python.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version='2019.10.41019'
+version='2021.8.1159798656'
 
 if [ ! -z "$1" ]; then
     version="$1"

--- a/configs/vscode/run
+++ b/configs/vscode/run
@@ -2,4 +2,4 @@
 su $USER -c 'cd ~ && \
 export SHELL=/bin/bash && \
 cat /etc/profile > ~/.bashrc && \
-/usr/local/bin/code-server --auth none --disable-telemetry "$HOME"'
+/usr/local/bin/code-server --auth none --disable-telemetry "$HOME" --bind-addr 0.0.0.0:8080'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,16 @@ mv -f /etc/cont-init.d/userconf /tmp/userconf.sh
 chmod +x /tmp/userconf.sh
 source /tmp/userconf.sh
 
+# set up rstudio conf
+if [[ ! -z $WWW_ROOT_PATH ]]
+then
+    echo "Set www-root-path to $WWW_ROOT_PATH"
+    echo "www-root-path=$WWW_ROOT_PATH" >> /etc/rstudio/rserver_custom.conf
+else
+    echo "Not setting www-root-path"
+fi
+
+
 site_dir="/home/${USER}/__ShinyStudio__"
 if [ -d "$site_dir" ]; then
     


### PR DESCRIPTION
Hi!

This PR updates the underlying rocker image to R 4.1.1 and updates other software versions, with a few associated updates:
* Update JDK to 11 (8 is no longer supported in the rocker image)
* Use Ubuntu deb for PowerShell now that the image is Ubuntu based
* Update the RStudio config location (moved in recent versions)
* Updates for recent code-server

This should close #1